### PR TITLE
feat: Add tests to the 'testing' object

### DIFF
--- a/src/rez/data/tests/builds/packages/testing_obj/1.0.0/build.py
+++ b/src/rez/data/tests/builds/packages/testing_obj/1.0.0/build.py
@@ -1,0 +1,24 @@
+from build_util import build_directory_recurse
+import os.path
+
+
+def build(source_path, build_path, install_path, targets):
+
+    if "install" not in (targets or []):
+        install_path = None
+
+    build_directory_recurse(src_dir="testing_obj",
+                            dest_dir=os.path.join("python", "testing_obj"),
+                            source_path=source_path,
+                            build_path=build_path,
+                            install_path=install_path)
+
+
+if __name__ == '__main__':
+    import os, sys
+    build(
+        source_path=os.environ['REZ_BUILD_SOURCE_PATH'],
+        build_path=os.environ['REZ_BUILD_PATH'],
+        install_path=os.environ['REZ_BUILD_INSTALL_PATH'],
+        targets=sys.argv[1:]
+    )

--- a/src/rez/data/tests/builds/packages/testing_obj/1.0.0/package.py
+++ b/src/rez/data/tests/builds/packages/testing_obj/1.0.0/package.py
@@ -1,0 +1,31 @@
+name = 'testing obj'
+version = '1.0.0'
+authors = ["Dan Flashes"]
+
+description = "testing the 'testing' attribute available during rez test"
+
+@late()
+def requires():
+    if in_context() and testing:
+        return ["floob"]
+    return ["hello"]
+
+private_build_requires = ["build_util", "python"]
+
+def commands():
+    env.PYTHONPATH.append('{root}/python')
+    if testing:
+        env.CAR_IDEA = "STURDY STEERING WHEEL"
+    else:
+        env.SKIP_LUNCH = "False"
+
+build_command = 'python {root}/build.py {install}'
+
+tests = {
+    "check_car_ideas": {
+        "command": "[[ -z ${CAR_IDEA} ]] && exit 1 || exit 0"
+    },
+    "move_meeting_to_noon": {
+        "command": "[[ -z ${SKIP_LUNCH} ]] && exit 1 || exit 0"
+    }
+}

--- a/src/rez/data/tests/builds/packages/testing_obj/1.0.0/testing_obj/__init__.py
+++ b/src/rez/data/tests/builds/packages/testing_obj/1.0.0/testing_obj/__init__.py
@@ -1,0 +1,2 @@
+def hello():
+    return "This shirt was $150 out the door and the pattern's not that complicated"

--- a/src/rez/tests/test_context.py
+++ b/src/rez/tests/test_context.py
@@ -71,6 +71,32 @@ class TestContext(TestBase, TempdirMixin):
         stdout = stdout.strip()
         self.assertEqual(stdout, "Hello Rez World!")
 
+    def test_resolved_packages_testing_environ(self):
+        """Test resolving packages within a testing environment behaves correctly"""
+        packages_path = self.data_path("builds", "packages")
+        r = ResolvedContext(["testing_obj"], testing=True, package_paths=[packages_path])
+        resolvedPackages = [x.qualified_package_name for x in r.resolved_packages]
+        self.assertEqual(resolvedPackages, ["floob", "testing_obj-1.0.0"])
+
+    def test_execute_command_testing_environ(self):
+        """Test that execute_command properly sets test specific environ dict"""
+        self.inject_python_repo()
+        packages_path = self.data_path("builds", "packages")
+        r = ResolvedContext(["testing_obj"], testing=True, package_paths=[packages_path])
+        self._test_execute_command_test_environ(r)
+
+    def _test_execute_command_test_environ(self, r):
+        pycode = ("import os; "
+                  "print(os.getenv(\"CAR_IDEA\"));")
+
+        args = ["python", "-c", pycode]
+
+        p = r.execute_command(args, stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
+        stdout = stdout.strip()
+        parts = [x.strip() for x in stdout.decode("utf-8").split('\n')]
+        self.assertEqual(parts, ["STURDY STEERING WHEEL"])
+
     def test_execute_command_environ(self):
         """Test that execute_command properly sets environ dict."""
         self.inject_python_repo()

--- a/src/rez/tests/test_test.py
+++ b/src/rez/tests/test_test.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Rez Project
+
+"""
+test rez package.py unit tests
+"""
+from rez.tests.util import TestBase, TempdirMixin
+from rez.resolved_context import ResolvedContext
+from rez.package_test import PackageTestRunner
+
+class TestTest(TestBase, TempdirMixin):
+    @classmethod
+    def setUpClass(cls):
+        TempdirMixin.setUpClass()
+
+        packages_path = cls.data_path("builds", "packages")
+        cls.settings = dict(
+            packages_path = [packages_path],
+            package_filter=None,
+            implicit_packages=[],
+            warn_untimestamped=False,
+            resolve_caching=False
+        )
+    @classmethod
+    def tearDownClass(cls):
+        TempdirMixin.tearDownClass()
+
+    def test_1(self):
+        """package.py unit tests are correctly run in a testing environment"""
+        context = ResolvedContext(["testing_obj"])
+        self._run_tests(context)
+
+    def _run_tests(self, r):
+        """Run unit tests in package.py"""
+        runner = PackageTestRunner(
+            package_request="testing_obj",
+            package_paths=r.package_paths,
+            stop_on_fail=False,
+            verbose=2
+        )
+        
+        test_names = runner.get_test_names()
+
+        for test_name in test_names:
+                runner.run_test(test_name)
+
+        successful_test = self._get_test_result(runner, "check_car_ideas")
+        failed_test = self._get_test_result(runner, "move_meeting_to_noon")
+
+        self.assertEqual(runner.test_results.num_tests, 2)
+        self.assertEqual(successful_test["status"], "success")
+        self.assertEqual(failed_test["status"], "failed")
+    
+    def _get_test_result(self, runner, test_name):
+        return next((result for result in runner.test_results.test_results if result.get("test_name") == test_name), None)


### PR DESCRIPTION
Added unit and integration tests to the newly added testing object, which is available in late bindings similar to the building attribute to indicate rez-test context environments.